### PR TITLE
Transferring inventory generic expression errors

### DIFF
--- a/addons/overthrow_main/functions/UI/fn_choiceMade.sqf
+++ b/addons/overthrow_main/functions/UI/fn_choiceMade.sqf
@@ -2,4 +2,4 @@ private _choice = OT_choices select _this;
 _choice params ["_text","_code","_args"];
 if (isNil "_args") then { _args = [_text]; };
 
-[_code,_args] call CBA_fnc_waitAndExecute;
+_args spawn _code;

--- a/addons/overthrow_main/functions/actions/fn_transferHelper.sqf
+++ b/addons/overthrow_main/functions/actions/fn_transferHelper.sqf
@@ -19,12 +19,10 @@ if(_target == player) then {
 	_target = OT_warehouseTarget;
 };
 
-disableUserInput true;
 private _fromOrTo = ["to","from"] select _isToPlayer;
-format["Transferring inventory %2 %1",_toname,_fromOrTo] call OT_fnc_notifyMinor;
-[5,false] call OT_fnc_progressBar;
+format["Transferring inventory %2 %1...",_toname,_fromOrTo] call OT_fnc_notifyMinor;
+[5, false] call OT_fnc_progressBar;
 private _end = time + 5;
-
 // Dummy CBA remove calls to strip weapons and replace with non-preset types
 [_target, "Bag_Base"] call CBA_fnc_removeBackpackCargo;
 [_target, "FakeWeapon"] call CBA_fnc_removeWeaponCargo;
@@ -105,6 +103,6 @@ if(_isToPlayer && _iswarehouse) then {
 	}foreach(_target call OT_fnc_unitStock);
 };
 
-waitUntil {time > _end};
-disableUserInput false;
+waitUntil { time >= _end };
+
 "Inventory Transfer done" call OT_fnc_notifyMinor;


### PR DESCRIPTION
_CBA_fnc_waitAndExecute_ changed to use _spawn_ instead for the dialog choice actions. 

I'm not sure if this has any other implications for other choices (needs testing) but the transfer helper must be [scheduled](https://community.bistudio.com/wiki/Scheduler), otherwise we can't suspend the scripts with _sleep_, _waitUntil_, etc.

Also removed _disableUserInput_ temporarily as this causes lockups sometimes and I plan on fixing that.