### PR TITLE
Fix `OT_hasTFAR` undefined variable + remove useless/problematic loop

### DIFF
--- a/addons/overthrow_main/functions/fn_initOverthrow.sqf
+++ b/addons/overthrow_main/functions/fn_initOverthrow.sqf
@@ -34,10 +34,10 @@ publicVariable "OT_civilians";
 
 OT_centerPos = getArray (configFile >> "CfgWorlds" >> worldName >> "centerPosition");
 
+[] call OT_fnc_initTFAR;
+
 call compile preprocessFileLineNumbers "initVar.sqf";
 call OT_fnc_initVar;
-
-[] call OT_fnc_initTFAR;
 
 if(isServer) then {
     diag_log "Overthrow: Server Pre-Init";

--- a/addons/overthrow_main/functions/integration/fn_initTFAR.sqf
+++ b/addons/overthrow_main/functions/integration/fn_initTFAR.sqf
@@ -1,12 +1,4 @@
 OT_hasTFAR = false;
 if (isClass (configFile >> "CfgPatches" >> "task_force_radio")) then {
     OT_hasTFAR = true;
-    tf_radio_channel_name = "TaskForceRadio";
-    if(hasInterface) then {
-      ["init_TFAR","_counter%3 isEqualTo 0", "
-        call TFAR_fnc_sendVersionInfo;
-        ""task_force_radio_pipe"" callExtension ""dummy~"";
-        sleep 3;
-      "] call OT_fnc_addActionLoop;
-    };
 };


### PR DESCRIPTION
OT_hasTFAR is checked within fn_init.sqf which was being ran before the tfar init.