### PR TITLE
Add a separate initBaseVar

### DIFF
--- a/addons/overthrow_main/CfgFunctions.hpp
+++ b/addons/overthrow_main/CfgFunctions.hpp
@@ -7,6 +7,7 @@ class CfgFunctions
 			file = "\overthrow_main\functions";
 			class initVar {};
 			class initOverthrow {};
+			class initBaseVar {};
 		};
 
         class Cleanup
@@ -567,7 +568,6 @@ class CfgFunctions
 		class Integration
 		{
 			file = "\overthrow_main\functions\integration";
-			class initTFAR {};
 			class advancedTowingInit {};
 			class detectItems {};
 		};

--- a/addons/overthrow_main/campaign/missions/OverthrowMpAltis.Altis/initVar.sqf
+++ b/addons/overthrow_main/campaign/missions/OverthrowMpAltis.Altis/initVar.sqf
@@ -95,10 +95,7 @@ OT_NATO_Vehicles_AirGarrison = [
 	["B_Plane_CAS_01_F",1]
 ];
 
-//Check for jets dlc
-OT_hasJetsDLC = false;
-if("B_Plane_Fighter_01_F" isKindOf "Air") then {
-	OT_hasJetsDLC = true;
+if(OT_hasJetsDLC) then {
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_F",1];
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_Stealth_F",1];
 };

--- a/addons/overthrow_main/campaign/missions/OverthrowMpMalden.Malden/initVar.sqf
+++ b/addons/overthrow_main/campaign/missions/OverthrowMpMalden.Malden/initVar.sqf
@@ -95,10 +95,7 @@ OT_NATO_Vehicles_AirGarrison = [
 	["B_Plane_CAS_01_F",1]
 ];
 
-//Check for jets dlc
-OT_hasJetsDLC = false;
-if("B_Plane_Fighter_01_F" isKindOf "Air") then {
-	OT_hasJetsDLC = true;
+if(OT_hasJetsDLC) then {
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_F",1];
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_Stealth_F",1];
 };

--- a/addons/overthrow_main/campaign/missions/OverthrowMpTanoa.Tanoa/initVar.sqf
+++ b/addons/overthrow_main/campaign/missions/OverthrowMpTanoa.Tanoa/initVar.sqf
@@ -98,10 +98,7 @@ OT_NATO_Vehicles_AirGarrison = [
 	["B_Plane_CAS_01_F",1]
 ];
 
-//Check for jets dlc
-OT_hasJetsDLC = false;
-if("B_Plane_Fighter_01_F" isKindOf "Air") then {
-	OT_hasJetsDLC = true;
+if(OT_hasJetsDLC) then {
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_F",1];
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_Stealth_F",1];
 };

--- a/addons/overthrow_main/campaign/missions/OverthrowSpAltis.Altis/initVar.sqf
+++ b/addons/overthrow_main/campaign/missions/OverthrowSpAltis.Altis/initVar.sqf
@@ -95,10 +95,7 @@ OT_NATO_Vehicles_AirGarrison = [
 	["B_Plane_CAS_01_F",1]
 ];
 
-//Check for jets dlc
-OT_hasJetsDLC = false;
-if("B_Plane_Fighter_01_F" isKindOf "Air") then {
-	OT_hasJetsDLC = true;
+if(OT_hasJetsDLC) then {
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_F",1];
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_Stealth_F",1];
 };

--- a/addons/overthrow_main/campaign/missions/OverthrowSpMalden.Malden/initVar.sqf
+++ b/addons/overthrow_main/campaign/missions/OverthrowSpMalden.Malden/initVar.sqf
@@ -95,10 +95,7 @@ OT_NATO_Vehicles_AirGarrison = [
 	["B_Plane_CAS_01_F",1]
 ];
 
-//Check for jets dlc
-OT_hasJetsDLC = false;
-if("B_Plane_Fighter_01_F" isKindOf "Air") then {
-	OT_hasJetsDLC = true;
+if(OT_hasJetsDLC) then {
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_F",1];
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_Stealth_F",1];
 };

--- a/addons/overthrow_main/campaign/missions/OverthrowSpTanoa.Tanoa/initVar.sqf
+++ b/addons/overthrow_main/campaign/missions/OverthrowSpTanoa.Tanoa/initVar.sqf
@@ -98,10 +98,7 @@ OT_NATO_Vehicles_AirGarrison = [
 	["B_Plane_CAS_01_F",1]
 ];
 
-//Check for jets dlc
-OT_hasJetsDLC = false;
-if("B_Plane_Fighter_01_F" isKindOf "Air") then {
-	OT_hasJetsDLC = true;
+if(OT_hasJetsDLC) then {
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_F",1];
 	OT_NATO_Vehicles_AirGarrison pushback ["B_Plane_Fighter_01_Stealth_F",1];
 };

--- a/addons/overthrow_main/functions/fn_initBaseVar.sqf
+++ b/addons/overthrow_main/functions/fn_initBaseVar.sqf
@@ -1,0 +1,3 @@
+OT_hasAce = true;
+OT_hasTFAR = (isClass (configFile >> "CfgPatches" >> "task_force_radio"));
+OT_hasJetsDLC = ("B_Plane_Fighter_01_F" isKindOf "Air");

--- a/addons/overthrow_main/functions/fn_initOverthrow.sqf
+++ b/addons/overthrow_main/functions/fn_initOverthrow.sqf
@@ -34,8 +34,7 @@ publicVariable "OT_civilians";
 
 OT_centerPos = getArray (configFile >> "CfgWorlds" >> worldName >> "centerPosition");
 
-[] call OT_fnc_initTFAR;
-
+call OT_fnc_initBaseVar;
 call compile preprocessFileLineNumbers "initVar.sqf";
 call OT_fnc_initVar;
 

--- a/addons/overthrow_main/functions/fn_initVar.sqf
+++ b/addons/overthrow_main/functions/fn_initVar.sqf
@@ -121,7 +121,6 @@ OT_rankXP = [100,250,500,1000,4000,10000,100000];
 
 OT_adminMode = false;
 OT_deepDebug = false;
-OT_hasAce = true;
 OT_allIntel = [];
 OT_notifies = [];
 

--- a/addons/overthrow_main/functions/integration/fn_initTFAR.sqf
+++ b/addons/overthrow_main/functions/integration/fn_initTFAR.sqf
@@ -1,4 +1,0 @@
-OT_hasTFAR = false;
-if (isClass (configFile >> "CfgPatches" >> "task_force_radio")) then {
-    OT_hasTFAR = true;
-};


### PR DESCRIPTION
This allows for the definition of some vars that can be used within the mission specific initVar rather than having to check within every mission initVar